### PR TITLE
Fix gitlab runner cw logs

### DIFF
--- a/logging.tf
+++ b/logging.tf
@@ -2,7 +2,10 @@ resource "aws_iam_role_policy" "instance" {
   count  = var.enable_cloudwatch_logging ? 1 : 0
   name   = "${var.environment}-instance-role"
   role   = aws_iam_role.instance.name
-  policy = templatefile("${path.module}/policies/instance-logging-policy.json", { arn_format = var.arn_format })
+  policy = templatefile("${path.module}/policies/instance-logging-policy.json", {
+    arn_format     = var.arn_format
+    log_group_name = var.log_group_name != null ? var.log_group_name : var.environment
+  })
 }
 
 locals {

--- a/main.tf
+++ b/main.tf
@@ -37,6 +37,7 @@ locals {
       gitlab_runner       = local.template_gitlab_runner
       runner_user_data    = local.template_runner_machine_user_data
       user_data_trace_log = var.enable_runner_user_data_trace_log
+      log_group_name      = var.log_group_name != null ? var.log_group_name : var.environment
   })
 
   template_runner_machine_user_data = templatefile("${path.module}/template/runner-machine-user-data.tpl", {

--- a/policies/instance-logging-policy.json
+++ b/policies/instance-logging-policy.json
@@ -11,7 +11,7 @@
         "logs:DescribeLogStreams"
       ],
       "Resource": [
-        "${arn_format}:logs:*:*:*"
+        "${arn_format}:logs:*:*:*:${log_group_name}:*"
       ]
     }
   ]

--- a/template/logging.tpl
+++ b/template/logging.tpl
@@ -8,13 +8,23 @@ cat <<EOF >> /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d/gitl
         "collect_list": [
           {
             "file_path": "/var/log/dmesg",
-            "log_group_name": "{hostname}",
+            "log_group_name": "${log_group_name}",
             "log_stream_name": "{instance_id}/dmesg"
           },
           {
             "file_path": "/var/log/user-data.log",
-            "log_group_name": "{hostname}",
+            "log_group_name": "${log_group_name}",
             "log_stream_name": "{instance_id}/user-data"
+          },
+          {
+            "file_path": "/var/log/secure",
+            "log_group_name": "${log_group_name}",
+            "log_stream_name": "{instance_id}/secure"
+          },
+          {
+            "file_path": "/var/log/messages",
+            "log_group_name": "${log_group_name}",
+            "log_stream_name": "{instance_id}/messages"
           }
         ]
       }

--- a/template/logging.tpl
+++ b/template/logging.tpl
@@ -35,5 +35,9 @@ EOF
 
 # Append the GitLab CW Logs config to our existing configuration
 /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl \
+-a fetch-config -m ec2 \
+-c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
+
+/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl \
 -a append-config -m ec2 \
 -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d/gitlab.json -s

--- a/template/user-data.tpl
+++ b/template/user-data.tpl
@@ -5,6 +5,11 @@ if [[ $(echo ${user_data_trace_log}) == false ]]; then
   set -x
 fi
 
+# Set hostname to log_group_name (default is gitlab-runner)
+# This ensures any existing CW config which uses {hostname} will
+# place logs in the appropriate log group.
+hostnamectl set-hostname ${log_group_name}
+
 # Add current hostname to hosts file
 tee /etc/hosts <<EOL
 127.0.0.1   localhost localhost.localdomain $(hostname)


### PR DESCRIPTION
Update CW logging template to place all log files under the log_group_name log group (currently this is gitlab-runner). Additionally, limit the gitlab-runner-instance-role logging policy to only allow logging to the log_group_name log group.
